### PR TITLE
Version 2.0.8

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Unterlagen API
   description: Europace-API rund um hochgeladene Dokumente und freigegebene Unterlagen.
-  version: 2.0.7
+  version: 2.0.8
   termsOfService: https://developer.europace.de/terms/
 paths:
   /dokumente:


### PR DESCRIPTION
Neue Version, damit die Korrektur der push-nachrichten/swagger.yaml eingebunden werden kann

beachte bitte:
https://github.com/hypoport/ep-api-community/blob/master/API-RELEASE-CHECKLIST.md

Hier können die To-Dos abgehakt werden:
* [x] Neue Versionsnummer im Commit definiert
* [ ] Github Release erzeugt (nach dem Mergen in den Master)