### PR TITLE
[DUCK-1012] dokumentation der X-Europace-TraceId

### DIFF
--- a/push-nachrichten/swagger.yaml
+++ b/push-nachrichten/swagger.yaml
@@ -22,6 +22,11 @@ paths:
           schema:
             type: string
           description: SHA256 Signatur der Payload mit dem für den Webhook hinterlegten Secret
+        - in: header
+          name: X-Europace-TraceId
+          schema:
+            type: string
+          description: Diese ID ist für Fehleranalysen und Logging sehr hilfreich. Bitte geben Sie diese bei Supportanfragen mit an.
       responses:
         "200":
           description: Nachricht erfolgreich entgegengenommen


### PR DESCRIPTION
## Motivation
bei der Push Nachricht wird nun die X-Europace-TraceId mit übertragen

beachte bitte:
https://github.com/hypoport/ep-api-community/blob/master/API-RELEASE-CHECKLIST.md

Hier können die To-Dos abgehakt werden:
* [ ] Neue Versionsnummer im Commit definiert
* [ ] Github Release erzeugt (nach dem Mergen in den Master)
* [ ] Postman Collection angepasst (falls zutreffend)
