### PR TITLE
[DUCK-1228] Entfernt überflüssige Parameter

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -682,6 +682,13 @@ paths:
           required: false
           schema:
             type: string
+        - name: antragsNummer
+          in: query
+          description: z.T. beziehen sich die Angaben in der Seite auf Angaben im Vorgang
+            zum Zeitpunkt, als der Antrag angenommen wurde.
+          required: false
+          schema:
+            type: string
       requestBody:
         content:
           application/json:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -562,12 +562,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: vorgangsNummer
-          in: query
-          description: Wird Pflichtfeld - bitte anpassen --  Vorgangsnummer des Dokuments.
-          required: false
-          schema:
-            type: string
         - name: antragsNummer
           in: query
           description: z.T. beziehen sich die Angaben in der Seite auf Angaben im Vorgang
@@ -685,19 +679,6 @@ paths:
         - name: bezug
           in: query
           description: Der Bezug, der den Seiten zugeordnet werden soll.
-          required: false
-          schema:
-            type: string
-        - name: vorgangsNummer
-          in: query
-          description: Vorgangsnummer der zugeordneten Seiten.
-          required: true
-          schema:
-            type: string
-        - name: antragsNummer
-          in: query
-          description: z.T. beziehen sich die Angaben in der Seite auf Angaben im Vorgang
-            zum Zeitpunkt, als der Antrag angenommen wurde.
           required: false
           schema:
             type: string


### PR DESCRIPTION
## MOTIVATION
Im Zuge der backendseitigen Validierung von Vorgangs- und Antragsnummer ist aufgefallen, dass wir zwei Methoden mit überflüssigen Parametern haben. Diese werden hiermit entfernt, da sie anderweitig ermittelt oder gar nicht benötigt werden.


beachte bitte:
https://github.com/hypoport/ep-api-community/blob/master/API-RELEASE-CHECKLIST.md

Hier können die To-Dos abgehakt werden:
* [ ] Neue Versionsnummer im Commit definiert
* [ ] Github Release erzeugt (nach dem Mergen in den Master)
* [ ] Postman Collection angepasst (falls zutreffend)
