### PR TITLE
Fix invalid URL format in `info.contact.url`

### DIFF
--- a/push-nachrichten/swagger.yaml
+++ b/push-nachrichten/swagger.yaml
@@ -6,7 +6,7 @@ info:
   termsOfService: 'https://docs.api.europace.de/terms/'
   contact:
     name: Europace AG
-    url: www.europace.de
+    url: https://www.europace.de
     email: helpdesk@europace2.de
 servers:
   - url: 'https://pushnotifications.dokumente.europace2.de'


### PR DESCRIPTION
Must be a valid URL. Code generation with validation will fail otherwise. 

See the [OpenAPI specs](https://spec.openapis.org/oas/v3.0.0.html#contact-object):

> The URL pointing to the contact information. MUST be in the format of a URL.
